### PR TITLE
Use LALT for altchar

### DIFF
--- a/capsicain/configUtils.cpp
+++ b/capsicain/configUtils.cpp
@@ -501,7 +501,7 @@ bool parseKeywordCombo(std::string line, int &key, unsigned short(&mods)[5], std
     else if (funcName == "altchar")
     {
         strokeSeq.push_back({ VK_CPS_TEMPRELEASEKEYS, true }); //temp release LSHIFT if it is currently down
-        strokeSeq.push_back({ SC_RALT , true });
+        strokeSeq.push_back({ SC_LALT , true });
         for (int i = 0; i < funcParams.length(); i++)
         {
             char c = funcParams[i];
@@ -524,7 +524,7 @@ bool parseKeywordCombo(std::string line, int &key, unsigned short(&mods)[5], std
             strokeSeq.push_back({ (unsigned char)isc, true });
             strokeSeq.push_back({ (unsigned char)isc, false });
         }
-        strokeSeq.push_back({ SC_RALT , false });
+        strokeSeq.push_back({ SC_LALT , false });
         strokeSeq.push_back({ VK_CPS_TEMPRESTOREKEYS, false });
     }
     else if (funcName == "moddedkey")


### PR DESCRIPTION
When using a Windows keyboard layout definition that has the AltGr option, a layer in the software stack above the Interception device introduces virtual Control keys in the mix when the right Alt key is pressed. This has the following consequences for combinations with RALT + numpad keys.

- Resulting combinations of LCTR + RALT + NP1 to NP9 and NP+ are not translated to characters.
- User defined startmenu shortcut keys or application shortcut keys that use Ctrl+Alt+NP# fire.

This can be demonstrated by choosing an AltGr layout, like German or US International, in the Windows language configuration.

Using RALT in Capsicain function `altchar` is therefore not desirable.

This simple fix only replaces RALT with LALT in the translation from the `altchar` definition in the ini to the virtual key sequence that is played at runtime when that function is invoked.
