### PR TITLE
Enable AutoHotkey local configuration

### DIFF
--- a/capsicain/utils.cpp
+++ b/capsicain/utils.cpp
@@ -86,7 +86,7 @@ string startProgram(string processName, string dir)
     }
     else
     {
-        ShellExecuteA(NULL, "open", processName.c_str(), NULL, dir.c_str(), SW_SHOWDEFAULT);
+        ShellExecuteA(NULL, "open", path.c_str(), NULL, dir.c_str(), SW_SHOWDEFAULT);
     }
     return ret;
 }


### PR DESCRIPTION
According to its documentation, AutoHotkey takes a startup script from either
- the directory with AutoHotkey.exe
- the user Documents folder.

When AutoHotkey in the Capsicain directory is started by Capsicain, only the latter location works.

It appears that AutoHotkey takes the location where it is installed from the command that is used to invoke it. That is not how Capsicain currently starts AutoHotkey.exe.

This PR involves a small fix to use the full pathname to start a program from Capsicain.